### PR TITLE
Add encode/decode options to create store functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A tiny persistent store for [Nano Stores](https://github.com/nanostores/nanostor
 state manager. It stores data in `localStorage` and synchronize changes between
 browser tabs.
 
-* **Small.** from 193 bytes (minified and gzipped).
+* **Small.** from 217 bytes (minified and gzipped).
   Zero dependencies. It uses [Size Limit] to control size.
 * It has good **TypeScript**.
 * Framework agnostic. It supports SSR.

--- a/README.md
+++ b/README.md
@@ -107,6 +107,24 @@ import { createPersistentStore } from '@nanostores/persistent'
 export const draft = createPersistentStore('draft', '', { listen: false })
 ```
 
+### Persisted value processing
+
+`encode` and `decode` options can be set to process a value before setting or after getting it from the persistent engine
+
+```ts
+import { createPersistentStore } from '@nanostores/persistent'
+
+export const draft = createPersistentStore('draft', [], {
+  encode: JSON.stringify,
+  decode: (value) => {
+    try {
+      return JSON.parse(value)
+    } catch() {
+      return value
+    }
+  }
+})
+```
 
 ### Persistent Engine
 

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 import { createMap, createStore } from 'nanostores'
 
-let id = a => a
+let identity = a => a
 let storageEngine = {}
 let eventsEngine = { addEventListener() {}, removeEventListener() {} }
 if (typeof localStorage !== 'undefined') {
@@ -16,8 +16,8 @@ export function setPersistentEngine(storage, events) {
 }
 
 export function createPersistentStore(name, initial = undefined, opts = {}) {
-  let encode = opts.encode || id
-  let decode = opts.decode || id
+  let encode = opts.encode || identity
+  let decode = opts.decode || identity
   function listener(e) {
     if (e.key === name) {
       store.set(e.newValue)
@@ -48,8 +48,8 @@ export function createPersistentStore(name, initial = undefined, opts = {}) {
 }
 
 export function createPersistentMap(prefix, initial = {}, opts = {}) {
-  let encode = opts.encode || id
-  let decode = opts.decode || id
+  let encode = opts.encode || identity
+  let decode = opts.decode || identity
   function listener(e) {
     if (e.key.startsWith(prefix)) {
       store.setKey(e.key.slice(prefix.length), e.newValue)

--- a/package.json
+++ b/package.json
@@ -127,14 +127,14 @@
       "import": {
         "./index.js": "{ createPersistentStore }"
       },
-      "limit": "193 B"
+      "limit": "217 B"
     },
     {
       "name": "Map",
       "import": {
         "./index.js": "{ createPersistentMap }"
       },
-      "limit": "248 B"
+      "limit": "275 B"
     }
   ],
   "yaspeller": {


### PR DESCRIPTION
Motivation: only primitive values can be stored in localStorage. If I want to persist some complex value like an array of objects, I need a way to convert it to string and back.
encode and decode optional functions processes the value before storing it in the storageEngine and after reading the value from storageEngine.