### PR TITLE
Fix type of PersistentMapFactory

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -72,7 +72,7 @@ interface PersistentMapFactory {
     initial?: Value,
     opts?: PersistentSimpleOptions
   ): MapStore<Value>
-  <Value>(
+  <Value extends object>(
     name: string,
     initial: Value,
     opts: PersistentSimpleOptions & PersistentEncoder<Value>


### PR DESCRIPTION
The MapStore signature is `MapStore<Value extends object = any>`, so we need `Value extends object` here for proper typing.