### PR TITLE
Add support for events engines requiring a listeners per key

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,14 +172,17 @@ const storage = new Proxy({}, {
   }
 })
 
-// Must implement addEventListener and removeEventListener for `storage` event
+// Must implement addEventListener and removeEventListener
 const events = {
-  addEventListener (name, callback) {
+  addEventListener (key, callback) {
     listeners.push(callback)
   },
-  removeEventListener (name, callback) {
+  removeEventListener (key, callback) {
     listeners = listeners.filter(i => i !== callback)
-  }
+  },
+  // window dispatches "storage" events for any key change
+  // => One listener for all map keys is enough
+  perKey: false
 }
 
 setPersistentEngine(storage, events)
@@ -192,6 +195,8 @@ You need to specify bodies of `events.addEventListener`
 and `events.removeEventListener` only for environment with browser tabs
 or another reasons to storage synchronization.
 
+`perKey` makes `PersistentMap` add one listener for each of its keys, in addition to the one for all keys. This is relevant when events for key changes are only dispatched for keys that were specifically subscribed too.
+
 For TypeScript, we have `PersistentListener` and `PersistentEvent` types
 for events object.
 
@@ -199,10 +204,10 @@ for events object.
 import { PersistentListener, PersistentEvent } from '@nanostores/persistent'
 
 const events = {
-  addEventListener (name: 'storage', callback: PersistentListener) {
+  addEventListener (key: string, callback: PersistentListener) {
     …
   },
-  removeEventListener (name: 'storage', callback: PersistentListener) {
+  removeEventListener (key: string, callback: PersistentListener) {
     …
   }
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -196,8 +196,3 @@ export function getTestStorage(): Record<string, string>
  * ```
  */
 export function cleanTestStorage(): void
-
-/**
- * Adapts window to PersistentEvents contract
- */
-export const windowPersistentEvents: PersistentEvents

--- a/index.d.ts
+++ b/index.d.ts
@@ -14,6 +14,7 @@ export interface PersistentListener {
 export interface PersistentEvents {
   addEventListener(key: string, callback: PersistentListener): void
   removeEventListener(key: string, callback: PersistentListener): void
+  requiresListenerPerKey?: boolean
 }
 
 /**

--- a/index.d.ts
+++ b/index.d.ts
@@ -14,7 +14,7 @@ export interface PersistentListener {
 export interface PersistentEvents {
   addEventListener(key: string, callback: PersistentListener): void
   removeEventListener(key: string, callback: PersistentListener): void
-  requiresListenerPerKey?: boolean
+  perKey?: boolean
 }
 
 /**

--- a/index.d.ts
+++ b/index.d.ts
@@ -12,8 +12,8 @@ export interface PersistentListener {
 }
 
 export interface PersistentEvents {
-  addEventListener(event: string, callback: PersistentListener): void
-  removeEventListener(event: string, callback: PersistentListener): void
+  addEventListener(key: string, callback: PersistentListener): void
+  removeEventListener(key: string, callback: PersistentListener): void
 }
 
 /**
@@ -195,3 +195,8 @@ export function getTestStorage(): Record<string, string>
  * ```
  */
 export function cleanTestStorage(): void
+
+/**
+ * Adapts window to PersistentEvents contract
+ */
+export const windowPersistentEvents: PersistentEvents

--- a/index.js
+++ b/index.js
@@ -89,6 +89,9 @@ export function createPersistentMap(prefix, initial = {}, opts = {}) {
   let setKey = store.setKey
   store.setKey = (key, newValue) => {
     if (typeof newValue === 'undefined') {
+      if (eventsEngine.perKey) {
+        eventsEngine.removeEventListener(prefix + key, listener)
+      }
       delete storageEngine[prefix + key]
     } else {
       if (eventsEngine.perKey && !(prefix + key in storageEngine)) {

--- a/index.js
+++ b/index.js
@@ -7,16 +7,15 @@ if (typeof localStorage !== 'undefined') {
   storageEngine = localStorage
 }
 
-export const windowPersistentEvents = {
-  addEventListener(key, listener) {
-    window.addEventListener('storage', listener)
-  },
-  removeEventListener(key, listener) {
-    window.removeEventListener('storage', listener)
-  }
-}
 if (typeof window !== 'undefined') {
-  eventsEngine = windowPersistentEvents
+  eventsEngine = {
+    addEventListener(key, listener) {
+      window.addEventListener('storage', listener)
+    },
+    removeEventListener(key, listener) {
+      window.removeEventListener('storage', listener)
+    }
+  }
 }
 
 export function setPersistentEngine(storage, events) {

--- a/index.js
+++ b/index.js
@@ -73,7 +73,7 @@ export function createPersistentMap(prefix, initial = {}, opts = {}) {
     }
     store.set(data)
     if (opts.listen !== false) {
-      if (eventsEngine.requiresListenerPerKey) {
+      if (eventsEngine.perKey) {
         return () => {
           for (let key in store.value) {
             eventsEngine.removeEventListener(prefix + key, listener)
@@ -91,10 +91,7 @@ export function createPersistentMap(prefix, initial = {}, opts = {}) {
     if (typeof newValue === 'undefined') {
       delete storageEngine[prefix + key]
     } else {
-      if (
-        eventsEngine.requiresListenerPerKey &&
-        !(prefix + key in storageEngine)
-      ) {
+      if (eventsEngine.perKey && !(prefix + key in storageEngine)) {
         eventsEngine.addEventListener(prefix + key, listener)
       }
       storageEngine[prefix + key] = encode(newValue)

--- a/index.js
+++ b/index.js
@@ -73,15 +73,12 @@ export function createPersistentMap(prefix, initial = {}, opts = {}) {
     }
     store.set(data)
     if (opts.listen !== false) {
-      if (eventsEngine.perKey) {
-        return () => {
-          for (let key in store.value) {
-            eventsEngine.removeEventListener(prefix + key, listener)
-          }
+      eventsEngine.addEventListener(prefix, listener)
+      return () => {
+        eventsEngine.removeEventListener(prefix, listener)
+        for (let key in store.value) {
+          eventsEngine.removeEventListener(prefix + key, listener)
         }
-      } else {
-        eventsEngine.addEventListener(prefix, listener)
-        return () => eventsEngine.removeEventListener(prefix, listener)
       }
     }
   })

--- a/index.js
+++ b/index.js
@@ -6,8 +6,17 @@ let eventsEngine = { addEventListener() {}, removeEventListener() {} }
 if (typeof localStorage !== 'undefined') {
   storageEngine = localStorage
 }
+
+export const windowPersistentEvents = {
+  addEventListener(key, listener) {
+    window.addEventListener('storage', listener)
+  },
+  removeEventListener(key, listener) {
+    window.removeEventListener('storage', listener)
+  }
+}
 if (typeof window !== 'undefined') {
-  eventsEngine = window
+  eventsEngine = windowPersistentEvents
 }
 
 export function setPersistentEngine(storage, events) {
@@ -27,9 +36,9 @@ export function createPersistentStore(name, initial = undefined, opts = {}) {
   let store = createStore(() => {
     set(storageEngine[name] ? decode(storageEngine[name]) : initial)
     if (opts.listen !== false) {
-      eventsEngine.addEventListener('storage', listener)
+      eventsEngine.addEventListener(name, listener)
       return () => {
-        eventsEngine.removeEventListener('storage', listener)
+        eventsEngine.removeEventListener(name, listener)
       }
     }
   })
@@ -65,9 +74,9 @@ export function createPersistentMap(prefix, initial = {}, opts = {}) {
     }
     store.set(data)
     if (opts.listen !== false) {
-      eventsEngine.addEventListener('storage', listener)
+      eventsEngine.addEventListener(prefix, listener)
       return () => {
-        eventsEngine.removeEventListener('storage', listener)
+        eventsEngine.removeEventListener(prefix, listener)
       }
     }
   })
@@ -90,10 +99,10 @@ let testListeners = []
 
 export function useTestStorageEngine() {
   setPersistentEngine(testStorage, {
-    addEventListener(event, cb) {
+    addEventListener(key, cb) {
       testListeners.push(cb)
     },
-    removeEventListener(event, cb) {
+    removeEventListener(key, cb) {
       testListeners = testListeners.filter(i => i !== cb)
     }
   })

--- a/index.js
+++ b/index.js
@@ -86,12 +86,16 @@ export function createPersistentMap(prefix, initial = {}, opts = {}) {
   let setKey = store.setKey
   store.setKey = (key, newValue) => {
     if (typeof newValue === 'undefined') {
-      if (eventsEngine.perKey) {
+      if (opts.listen !== false && eventsEngine.perKey) {
         eventsEngine.removeEventListener(prefix + key, listener)
       }
       delete storageEngine[prefix + key]
     } else {
-      if (eventsEngine.perKey && !(prefix + key in storageEngine)) {
+      if (
+        opts.listen !== false &&
+        eventsEngine.perKey &&
+        !(key in store.value)
+      ) {
         eventsEngine.addEventListener(prefix + key, listener)
       }
       storageEngine[prefix + key] = encode(newValue)

--- a/package.json
+++ b/package.json
@@ -127,14 +127,14 @@
       "import": {
         "./index.js": "{ createPersistentStore }"
       },
-      "limit": "220 B"
+      "limit": "235 B"
     },
     {
       "name": "Map",
       "import": {
         "./index.js": "{ createPersistentMap }"
       },
-      "limit": "276 B"
+      "limit": "327 B"
     }
   ],
   "yaspeller": {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -400,10 +400,11 @@ describe('requiresListenerPerKey', () => {
     })
     let removeListener = settings.listen(() => {})
 
-    expect(mockEvents.addEventListener).toHaveBeenCalledTimes(2)
+    expect(mockEvents.addEventListener).toHaveBeenCalledTimes(3)
     expect(Object.keys(mockListeners)).toStrictEqual([
       'settings:lang',
-      'settings:theme'
+      'settings:theme',
+      'settings:'
     ])
 
     setMockStorageKey('settings:lang', 'es')
@@ -416,7 +417,7 @@ describe('requiresListenerPerKey', () => {
     expect(getValue(settings)).toStrictEqual({ lang: 'es', theme: 'blue' })
 
     removeListener()
-    expectAllListenersRemoved(2)
+    expectAllListenersRemoved(3)
   })
 
   it('map.setKey', () => {
@@ -428,8 +429,9 @@ describe('requiresListenerPerKey', () => {
     settings.setKey('theme', 'dark')
     settings.setKey('theme', 'light')
 
-    expect(mockEvents.addEventListener).toHaveBeenCalledTimes(2)
+    expect(mockEvents.addEventListener).toHaveBeenCalledTimes(3)
     expect(Object.keys(mockListeners)).toStrictEqual([
+      'settings:',
       'settings:lang',
       'settings:theme'
     ])
@@ -444,7 +446,7 @@ describe('requiresListenerPerKey', () => {
     expect(getValue(settings)).toStrictEqual({ lang: 'es', theme: 'blue' })
 
     removeListener()
-    expectAllListenersRemoved(2)
+    expectAllListenersRemoved(3)
   })
 
   it('map.set', () => {
@@ -455,8 +457,9 @@ describe('requiresListenerPerKey', () => {
       theme: 'dark'
     })
 
-    expect(mockEvents.addEventListener).toHaveBeenCalledTimes(2)
+    expect(mockEvents.addEventListener).toHaveBeenCalledTimes(3)
     expect(Object.keys(mockListeners)).toStrictEqual([
+      'settings:',
       'settings:lang',
       'settings:theme'
     ])
@@ -471,6 +474,7 @@ describe('requiresListenerPerKey', () => {
     expect(getValue(settings)).toStrictEqual({ lang: 'es', theme: 'blue' })
 
     removeListener()
+    expectAllListenersRemoved(3)
   })
 
   it('remove map key', () => {
@@ -500,8 +504,9 @@ describe('requiresListenerPerKey', () => {
       theme: 'dark'
     })
 
-    expect(mockEvents.addEventListener).toHaveBeenCalledTimes(2)
+    expect(mockEvents.addEventListener).toHaveBeenCalledTimes(3)
     expect(Object.keys(mockListeners)).toStrictEqual([
+      'settings:',
       'settings:lang',
       'settings:theme'
     ])

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -9,7 +9,8 @@ import {
   PersistentListener,
   setTestStorageKey,
   cleanTestStorage,
-  getTestStorage
+  getTestStorage,
+  windowPersistentEvents
 } from '../index.js'
 
 afterEach(() => {
@@ -188,17 +189,17 @@ describe('engine', () => {
 
   afterEach(() => {
     cleanStores(map, store)
-    setPersistentEngine(localStorage, window)
+    setPersistentEngine(localStorage, windowPersistentEvents)
   })
 
   it('changes engine', () => {
     let storage: Record<string, string> = {}
     let listeners: PersistentListener[] = []
     let events = {
-      addEventListener(name: 'storage', callback: PersistentListener) {
+      addEventListener(key: string, callback: PersistentListener) {
         listeners.push(callback)
       },
-      removeEventListener(name: 'storage', callback: PersistentListener) {
+      removeEventListener(key: string, callback: PersistentListener) {
         listeners = listeners.filter(i => i !== callback)
       }
     }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -332,7 +332,7 @@ describe('requiresListenerPerKey', () => {
       removeEventListener: jest.fn(key => {
         delete mockListeners[key]
       }),
-      requiresListenerPerKey: true
+      perKey: true
     }
     setPersistentEngine(mockStorage, mockEvents)
   }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -11,13 +11,21 @@ import {
   setTestStorageKey,
   cleanTestStorage,
   getTestStorage,
-  windowPersistentEvents,
   PersistentEvents
 } from '../index.js'
 
 afterEach(() => {
   localStorage.clear()
 })
+
+const windowPersistentEvents: PersistentEvents = {
+  addEventListener(key: string, listener: PersistentListener) {
+    window.addEventListener('storage', listener as unknown as EventListener)
+  },
+  removeEventListener(key: string, listener: PersistentListener) {
+    window.removeEventListener('storage', listener as unknown as EventListener)
+  }
+}
 
 function clone(data: object): object {
   return JSON.parse(JSON.stringify(data))

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -471,7 +471,25 @@ describe('requiresListenerPerKey', () => {
     expect(getValue(settings)).toStrictEqual({ lang: 'es', theme: 'blue' })
 
     removeListener()
-    expectAllListenersRemoved(2)
+  })
+
+  it('remove map key', () => {
+    let settings = createPersistentMap('settings:', {
+      lang: 'en',
+      theme: 'dark'
+    })
+    let removeListener = settings.listen(() => {})
+
+    settings.setKey('lang', undefined as unknown as string)
+
+    expect(mockEvents.removeEventListener).toHaveBeenCalledTimes(1)
+    expect(Object.keys(mockListeners)).toStrictEqual([
+      'settings:theme',
+      'settings:'
+    ])
+
+    removeListener()
+    expectAllListenersRemoved(1 + 2)
   })
 
   it('map does not listen to new keys', () => {

--- a/test/types.ts
+++ b/test/types.ts
@@ -2,8 +2,17 @@ import {
   createPersistentStore,
   createPersistentMap,
   setPersistentEngine,
-  windowPersistentEvents
+  PersistentListener
 } from '../index.js'
+
+const windowPersistentEvents = {
+  addEventListener(key: string, listener: PersistentListener) {
+    window.addEventListener('storage', listener as unknown as EventListener)
+  },
+  removeEventListener(key: string, listener: PersistentListener) {
+    window.removeEventListener('storage', listener as unknown as EventListener)
+  }
+}
 
 setPersistentEngine(localStorage, windowPersistentEvents)
 

--- a/test/types.ts
+++ b/test/types.ts
@@ -1,10 +1,11 @@
 import {
   createPersistentStore,
   createPersistentMap,
-  setPersistentEngine
+  setPersistentEngine,
+  windowPersistentEvents
 } from '../index.js'
 
-setPersistentEngine(localStorage, window)
+setPersistentEngine(localStorage, windowPersistentEvents)
 
 let settings = createPersistentMap<{
   favorite?: string


### PR DESCRIPTION
Implementation for #9

"requiresListenerPerKey" was added to proposed new API:
```ts
interface PersistentEvents {
  addEventListener(key: string, callback: PersistentListener): void
  removeEventListener(key: string, callback: PersistentListener): void
  requiresListenerPerKey?: boolean
}
```

Size changes:
- Store: 220B -> 240 B (+20 B)
- Map: 276B -> 343 B (+ 67 B)