### PR TITLE
Fixup the remove key from localStorage

### DIFF
--- a/index.js
+++ b/index.js
@@ -85,7 +85,7 @@ export function createPersistentMap(prefix, initial = {}, opts = {}) {
 
   let setKey = store.setKey
   store.setKey = (key, newValue) => {
-    if (typeof newValue === 'undefined') {
+    if (newValue === null || typeof newValue === 'undefined') {
       if (opts.listen !== false && eventsEngine.perKey) {
         eventsEngine.removeEventListener(prefix + key, listener)
       }


### PR DESCRIPTION
When we delete an entry from localStorage (aka `localStorage.removeItem`), null will come in the newValue field in onstorage. If you then pass null to `setItem`, it will be converted to a string and written to the store as a string.

Now if you try to delete the field when several tabs are open, the field will not be deleted but will be replaced with the string 'null'.