### PR TITLE
add the type to the map store in the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ export type SettingsValue = {
   theme: 'dark' | 'light' | 'auto'
 }
 
-export const settings = persistentMap('settings:', {
+export const settings = persistentMap<SettingsValue>('settings:', {
   sidebar: 'show',
   theme: 'auto'
 })


### PR DESCRIPTION
Small fix in the documentation, the type **SettingsValue** is created but is not passed in the **persistentMap** function