### PR TITLE
Add error boundary around localStorage access

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,15 @@ import { map, atom, onMount } from 'nanostores'
 let identity = a => a
 let storageEngine = {}
 let eventsEngine = { addEventListener() {}, removeEventListener() {} }
-if (typeof localStorage !== 'undefined') {
+
+function localStorageSupported() {
+  try {
+    return typeof localStorage !== 'undefined'
+  } catch {
+    return false
+  }
+}
+if (localStorageSupported()) {
   storageEngine = localStorage
 }
 


### PR DESCRIPTION
Since browsers may [throw an exception upon access of localStorage](https://twitter.com/tomayac/status/1564612312740265987) in incognito tabs (or if security policy is set to deny localStorage access) simply checking the typeof of localStorage may throw an error, breaking this package.

As @tomayac said [on twitter](https://twitter.com/tomayac/status/1564960946489024514) adding a try-catch around the initial check should be good enough to prevent errors. Changing security policies in the browser requires a refresh of the tab, thus checking once should be plenty.