### PR TITLE
Allow setting custom storage engine per atom

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -52,7 +52,7 @@ interface PersistentSimpleOptions {
   /**
    * Custom storage engine for this atom
    */
-  storageEngine?: PersistentStore
+  engine?: PersistentStore
 }
 
 export type PersistentOptions =

--- a/index.d.ts
+++ b/index.d.ts
@@ -49,6 +49,10 @@ interface PersistentSimpleOptions {
    * Does not synchronize changes from other browser tabs
    */
   listen?: boolean
+  /**
+   * Custom storage engine for this atom
+   */
+  storageEngine?: PersistentStore
 }
 
 export type PersistentOptions =

--- a/index.js
+++ b/index.js
@@ -38,15 +38,16 @@ export function setPersistentEngine(storage, events) {
 export function persistentAtom(name, initial = undefined, opts = {}) {
   let encode = opts.encode || identity
   let decode = opts.decode || identity
+  let atomStorageEngine = opts.storageEngine || storageEngine;
 
   let store = atom(initial)
 
   let set = store.set
   store.set = newValue => {
     if (typeof newValue === 'undefined') {
-      delete storageEngine[name]
+      delete atomStorageEngine[name]
     } else {
-      storageEngine[name] = encode(newValue)
+      atomStorageEngine[name] = encode(newValue)
     }
     set(newValue)
   }
@@ -58,13 +59,13 @@ export function persistentAtom(name, initial = undefined, opts = {}) {
       } else {
         set(decode(e.newValue))
       }
-    } else if (!storageEngine[name]) {
+    } else if (!atomStorageEngine[name]) {
       set(undefined)
     }
   }
 
   onMount(store, () => {
-    store.set(storageEngine[name] ? decode(storageEngine[name]) : initial)
+    store.set(atomStorageEngine[name] ? decode(atomStorageEngine[name]) : initial)
     if (opts.listen !== false) {
       eventsEngine.addEventListener(name, listener)
       return () => {

--- a/index.js
+++ b/index.js
@@ -38,16 +38,16 @@ export function setPersistentEngine(storage, events) {
 export function persistentAtom(name, initial = undefined, opts = {}) {
   let encode = opts.encode || identity
   let decode = opts.decode || identity
-  let atomStorageEngine = opts.storageEngine || storageEngine;
+  let atomEngine = opts.engine || storageEngine;
 
   let store = atom(initial)
 
   let set = store.set
   store.set = newValue => {
     if (typeof newValue === 'undefined') {
-      delete atomStorageEngine[name]
+      delete atomEngine[name]
     } else {
-      atomStorageEngine[name] = encode(newValue)
+      atomEngine[name] = encode(newValue)
     }
     set(newValue)
   }
@@ -59,13 +59,13 @@ export function persistentAtom(name, initial = undefined, opts = {}) {
       } else {
         set(decode(e.newValue))
       }
-    } else if (!atomStorageEngine[name]) {
+    } else if (!atomEngine[name]) {
       set(undefined)
     }
   }
 
   onMount(store, () => {
-    store.set(atomStorageEngine[name] ? decode(atomStorageEngine[name]) : initial)
+    store.set(atomEngine[name] ? decode(atomEngine[name]) : initial)
     if (opts.listen !== false) {
       eventsEngine.addEventListener(name, listener)
       return () => {

--- a/index.js
+++ b/index.js
@@ -38,7 +38,7 @@ export function setPersistentEngine(storage, events) {
 export function persistentAtom(name, initial = undefined, opts = {}) {
   let encode = opts.encode || identity
   let decode = opts.decode || identity
-  let atomEngine = opts.engine || storageEngine;
+  let atomEngine = opts.engine || storageEngine
 
   let store = atom(initial)
 

--- a/package.json
+++ b/package.json
@@ -89,14 +89,14 @@
       "import": {
         "./index.js": "{ persistentAtom }"
       },
-      "limit": "332 B"
+      "limit": "340 B"
     },
     {
       "name": "Map",
       "import": {
         "./index.js": "{ persistentMap }"
       },
-      "limit": "461 B"
+      "limit": "462 B"
     }
   ],
   "clean-publish": {

--- a/test/atom.test.ts
+++ b/test/atom.test.ts
@@ -43,6 +43,21 @@ test('saves to localStorage', () => {
   equal(events, ['1', undefined])
 })
 
+test('saves to a custom storage', () => {
+  let customStorageEngine = {};
+  atom = persistentAtom<string | undefined>('b', undefined, {
+    engine: customStorageEngine
+  })
+
+  is(atom.get(), undefined)
+
+  atom.set('1')
+  equal(customStorageEngine, { b: '1' })
+
+  atom.set(undefined)
+  equal(customStorageEngine, {})
+})
+
 test('listens for other tabs', () => {
   atom = persistentAtom('c')
 


### PR DESCRIPTION
Closes #27

This is my shot at implementing a custom engine per atom. My particular use case: using one store in `localStorage` and the other in `sessionStorage`.
