### PR TITLE
Fix removed keys in persistent map restoration

### DIFF
--- a/index.js
+++ b/index.js
@@ -175,9 +175,7 @@ export function persistentMap(prefix, initial = {}, opts = {}) {
         data[key.slice(prefix.length)] = decode(storageEngine[key])
       }
     }
-    for (let key in data) {
-      store.setKey(key, data[key])
-    }
+    store.set(data)
   }
 
   onMount(store, () => {

--- a/test/map.test.ts
+++ b/test/map.test.ts
@@ -211,6 +211,30 @@ describe('persistentMap', () => {
     deepStrictEqual(storage, {})
   })
 
+  test('restores removed keys after page cache', () => {
+    let storage: Record<string, string> = {
+      'settings:one': '1',
+      'settings:stale': '2'
+    }
+    let restore = (): void => {}
+    setPersistentEngine(storage, {
+      addEventListener(key, listener, onRestore) {
+        restore = onRestore
+      },
+      removeEventListener() {}
+    })
+
+    map = persistentMap('settings:')
+    map.listen(() => {})
+    deepStrictEqual(map.get(), { one: '1', stale: '2' })
+
+    storage['settings:one'] = '1a'
+    delete storage['settings:stale']
+    restore()
+
+    deepStrictEqual(map.get(), { one: '1a' })
+  })
+
   test('supports per key engine', async () => {
     let storage: Record<string, string> = {}
     let listeners: Record<string, PersistentListener> = {}


### PR DESCRIPTION
## Summary

Remove stale `persistentMap` keys when storage is restored after a page-cache transition.

## Problem

The `pageshow` restore path rebuilds the map data from its initial value and current storage, but previously updated only keys present in that rebuilt object. If a storage key was removed while the page was cached, its old value remained in the in-memory map after restoration.

## Changes

- Reuse the map's existing full-object setter during restoration so additions, updates, and removals are reconciled together.
- Add a regression test covering an updated surviving key and a removed stale key.

## Testing

- `pnpm bnt test/map.test.ts`
- `pnpm exec bnt --coverage 100 --coverage-exclude "test/*"`
- `pnpm test:lint`
- `pnpm test:types`
- `pnpm test:build`
- `pnpm test:size`

## Before

After storage changed from `{ one: "1", stale: "2" }` to `{ one: "1a" }` while the page was cached, restoration produced `{ one: "1a", stale: "2" }`.

## After

Restoration replaces the map with the current initial-plus-storage state, producing `{ one: "1a" }` and removing the stale key.

## Compatibility

No public API or type changes. The correction affects only persistent-map restoration and reuses existing storage and per-key-listener reconciliation. Runtime behavior is platform-neutral.

## Related issue

None; independently reproduced on the current default branch.
